### PR TITLE
update cutout tool to DR5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # decals-image-list-tool
-A simple webpage to generate image cutouts of the [Dark Energy Camera Legacy Survey](http://legacysurvey.org/) (DECaLS)
+A simple webpage to generate image cutouts of the [Dark Energy Camera Legacy Survey](http://legacysurvey.org/) (DECaLS).
 
 This tool is similar to the [SDSS Image List Tool](https://skyserver.sdss.org/dr13/en/tools/chart/listinfo.aspx). 

--- a/index.html
+++ b/index.html
@@ -93,9 +93,9 @@
     <p>
     <select id="layer" class="optiongroup">
       <option disabled selected value style="display: none;"> -- Select a layer -- </option>
-      <option value="decals-dr3" id="default-layer">DECaLS DR3</option>
-      <option value="decals-dr3-model">DECaLS DR3 Model</option>
-      <option value="decals-dr3-resid">DECaLS DR3 Residual</option>
+      <option value="decals-dr5" id="default-layer">DECaLS DR5</option>
+      <option value="decals-dr5-model">DECaLS DR5 Model</option>
+      <option value="decals-dr5-resid">DECaLS DR5 Residual</option>
       <option value="mzls+bass-dr4">MzLS+BASS DR4</option>
       <option value="mzls+bass-dr4-model">MzLS+BASS DR4 Model</option>
       <option value="mzls+bass-dr4-resid">MzLS+BASS DR4 Residual</option>


### PR DESCRIPTION
Simple PR to update the default DECaLS data release version to DR5, which was just released today.