### PR TITLE
Switch legacysurvey.org cutout links to https

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
     <button id="generate_output" class="pure-button" disabled>Record marks</button>
     </p>
     <p class="credit">
-      Cutout images are retrieved from <a href="http://legacysurvey.org/viewer">Legacy Surveys Viewer</a>.
+      Cutout images are retrieved from <a href="https://www.legacysurvey.org/viewer">Legacy Surveys Viewer</a>.
       Web interface made by <a href="https://yymao.github.io">Yao-Yuan Mao</a>.
       <a href="https://github.com/yymao/decals-image-list-tool/issues">Issues?</a><br>
       <i>
@@ -176,8 +176,8 @@ const _default_layer = $("#default-layer").attr("value");
 const _sdss_layer = $("#sdss-layer").attr("value");
 
 const _use_dev = (window.location.hash.substr(1) == "dev")? "-dev" : "";
-const _image_url = "http://legacysurvey.org/viewer" + _use_dev + "/cutout.jpg?ra=${ra}&dec=${dec}&${scale_unit}=${scale}&layer=${layer}&size=180";
-const _link_url = "http://legacysurvey.org/viewer" + _use_dev + "?ra=${ra}&dec=${dec}&zoom=14&layer=${layer}";
+const _image_url = "https://www.legacysurvey.org/viewer" + _use_dev + "/cutout.jpg?ra=${ra}&dec=${dec}&${scale_unit}=${scale}&layer=${layer}&size=180";
+const _link_url = "https://www.legacysurvey.org/viewer" + _use_dev + "?ra=${ra}&dec=${dec}&zoom=14&layer=${layer}";
 const _link_url_alt = "http://viewer.legacysurvey.org/?ra=${ra}&dec=${dec}&zoom=14&layer=${layer}";
 
 const _image_url_sdss = "http://skyserver.sdss.org/dr16/SkyServerWS/ImgCutout/getjpeg?TaskName=Skyserver.Chart.List&ra=${ra}&dec=${dec}&scale=${scale}&width=180&height=180";

--- a/index.html
+++ b/index.html
@@ -113,14 +113,14 @@
       <option value="dr9sv">Legacy Surveys DR9 SV (5% sky)</option>
       <option value="dr9sv-model">Legacy Surveys DR9 SV Model</option>
       <option value="dr9sv-resid">Legacy Surveys DR9 SV Residual</option>
-      <option value="sdss2">SDSS (source: Legacy Surveys)</option>
+      <option value="sdss">SDSS (source: Legacy Surveys)</option>
       <option value="sdss-dr16" id="sdss-layer">SDSS (source: SDSS)</option>
       <option value="des-dr1">DES DR1</option>
       <option value="hsc2">HSC DR2</option>
       <option value="ls-dr67">Legacy Surveys DR6+DR7</option>
       <option value="decaps">DECaPS</option>
-      <option value="unwise-neo4">unWISE NEO4</option>
-      <option value="vlass">VLASS</option>
+      <option value="unwise-neo6">unWISE NEO6</option>
+      <option value="vlass1.2">VLASS</option>
       <option value="galex">GALEX</option>
       <option value="wssa">WISE 12-μm dust</option>
       <option value="sfd">SFD Dust</option>


### PR DESCRIPTION
Hi Yao,

Jeff Newman reported a problem with the cutouts displaying now that we've mostly switched to https.

This switches the few legacysurvey.org/viewer links to https.

I also updated a couple of layer names.  The "sdss2" to "sdss" one is just a renaming/cleanup.  Similarly, "vlass" to "vlass1.2" is the same data, just renamed.  I also switch "unwise-neo4" to "unwise-neo6" -- an extra 2 years of data there. 
